### PR TITLE
ARCH-1804 - Update default login value

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
 
       - name: Cleanup
         # You may also reference just the major or major.minor version
-        uses: im-open/cleanup-deployment-board@v1.1.4
+        uses: im-open/cleanup-deployment-board@v1.1.5
         with:
           github-token: ${{ secrets.BOT_TOKEN}} 
           github-login: 'my-bot'  # The login that created the deployment cards to begin with.  Defaults to github-actions.

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,6 @@ inputs:
   github-login:
     description: 'The login associated with the account that created the deployment cards.  Defaults to github-actions.'
     required: true
-    default: 'github-actions'
   branch-cleanup-strategy:
     description: 'The cleanup strategy for Branch Deployment cards.  Accepted Values: age|number'
     required: true


### PR DESCRIPTION
Remove the default action value for github login since it has the correct default in code.

# Summary of PR changes

Tested the cleanup workflow [here](https://github.com/im-enrollment/underwriting/actions/runs/4408929026/jobs/7724572165).  

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
